### PR TITLE
support normalizing polymorphic relationships

### DIFF
--- a/src/json-api-serializer.js
+++ b/src/json-api-serializer.js
@@ -234,15 +234,25 @@ function hasManyLink(key, type, record, attr) {
   return { linkage: linkages };
 }
 
+function getIdObject(linkage) {
+  if (linkage.id && linkage.type) {
+    return {
+      id: linkage.id,
+      type: Ember.String.camelize(linkage.type.singularize())
+    };
+  } else {
+    return linkage.id;
+  }
+}
 function getLinkageId(linkage) {
   if(Ember.isEmpty(linkage)) { return null; }
-  return (Ember.isArray(linkage)) ? getLinkageIds(linkage) : linkage.id;
+  return (Ember.isArray(linkage)) ? getLinkageIds(linkage) : getIdObject(linkage);
 }
 function getLinkageIds(linkage) {
   if(Ember.isEmpty(linkage)) { return null; }
   var ids = [], index, total;
   for(index=0, total=linkage.length; index<total; ++index) {
-    ids.push(linkage[index].id);
+    ids.push(getIdObject(linkage[index]));
   }
   return ids;
 }

--- a/tests/helpers/setup-polymorphic-models.js
+++ b/tests/helpers/setup-polymorphic-models.js
@@ -1,0 +1,27 @@
+var Owner, Pet, Cat, Dog;
+
+function setPolymorphicModels() {
+  Owner = DS.Model.extend({
+    name: DS.attr('string'),
+    pets: DS.hasMany('pets', {polymorphic: true})
+  });
+
+  Pet = DS.Model.extend({
+    paws: DS.attr('number')
+  });
+
+  Cat = Pet.extend({
+    whiskers: DS.attr('number')
+  });
+
+  Dog = Pet.extend({
+    spots: DS.attr('number')
+  });
+
+  return {
+    'owner': Owner,
+    'pet': Pet,
+    'cat': Cat,
+    'dog': Dog
+  };
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -25,11 +25,13 @@
   <script src='../tests/helpers/begin.js'></script>
   <script src='../tests/helpers/setup-store.js'></script>
   <script src='../tests/helpers/setup-models.js'></script>
+  <script src='../tests/helpers/setup-polymorphic-models.js'></script>
 
   <script src='../tests/integration/specs/individual-resource-representations-test.js'></script>
   <script src='../tests/integration/specs/resource-collection-representations-test.js'></script>
   <script src='../tests/integration/specs/to-one-relationships-test.js'></script>
   <script src='../tests/integration/specs/to-many-relationships-test.js'></script>
+  <script src='../tests/integration/specs/to-many-polymorphic-test.js'></script>
   <script src='../tests/integration/specs/urls-for-resource-collections-test.js'></script>
   <script src='../tests/integration/specs/href-link-for-resource-collection-test.js'></script>
   <script src='../tests/integration/specs/multiple-resource-links-test.js'></script>

--- a/tests/integration/specs/to-many-polymorphic-test.js
+++ b/tests/integration/specs/to-many-polymorphic-test.js
@@ -1,0 +1,81 @@
+var get = Ember.get, set = Ember.set;
+var env;
+var responses, fakeServer;
+
+module('integration/specs/to-many-polymorphic', {
+  setup: function() {
+    fakeServer = stubServer();
+
+    responses = {
+      data: {
+        type: 'owners',
+        id: '1',
+        name: 'Luke',
+        links: {
+          pets: {
+            linkage: [
+              {
+                type: 'cats',
+                id: 'cat_1'
+              },
+              {
+                type: 'dogs',
+                id: 'dog_2'
+              }
+            ]
+          }
+        }
+      },
+      included: [
+        {
+          type: 'cats',
+          id: 'cat_1',
+          whiskers: 4,
+          paws: 3
+        },
+        {
+          type: 'dogs',
+          id: 'dog_2',
+          spots: 7,
+          paws: 5
+        }
+      ]
+    };
+
+    env = setupStore(setPolymorphicModels());
+    env.store.modelFor('owner');
+    env.store.modelFor('pet');
+    env.store.modelFor('dog');
+    env.store.modelFor('cat');
+  },
+
+  teardown: function() {
+    Ember.run(env.store, 'destroy');
+    shutdownFakeServer(fakeServer);
+  }
+});
+
+asyncTest('GET /owners/1 with sync included resources', function() {
+  var models = setPolymorphicModels();
+  env = setupStore(models);
+
+  fakeServer.get('/owners/1', responses);
+
+  Em.run(function() {
+    env.store.find('owner', '1').then(function(record) {
+
+      equal(record.get('id'), '1', 'id is correct');
+      equal(record.get('name'), 'Isaac', 'name is correct');
+
+      var cat = record.get('pets.firstObject');
+      var dog = record.get('pets.lastObject');
+
+      equal(cat.get('paws'), 3, 'common prop from base class correct on cat');
+      equal(dog.get('paws'), 5, 'common prop from base class correct on dog');
+      equal(cat.get('whiskers'), 4, 'cat has correct whiskers (cat-only prop)');
+      equal(dog.get('spots'), 7, 'dog has correct spots (dog-only prop)');
+
+      start();
+    });
+  });
+});


### PR DESCRIPTION
@eneuhauser I'm using your fork of ember-json-api on a project and would like to merge this fix. I'm on the jsonapi-rc3 branch.

This PR gets Ember Data to normalize polymorphic relationships correctly when you get something like:

```
links: {
  pets: {
    linkage: [
      {
        type: 'cats',
        id: 'cat_1'
      },
      {
        type: 'dogs',
        id: 'dog_2'
      }
    ]
  }
}
```

Ember Data expects to get an ID (number or string) for objects in a linkage, except if it's polymorphic in which case it expects an object with an id and type, for example {id: '1', type: 'people'}. See https://github.com/emberjs/data/blob/v1.0.0-beta.16.1/packages/ember-data/lib/system/store.js#L1973-L1981

The id/type object works in all cases in ED so this PR sets up that object. If you run the test suite without the change to `json-api-serializer.js`, ED will throw an exception.
