### PR TITLE
Use Ember.String.singularize

### DIFF
--- a/src/json-api-serializer.js
+++ b/src/json-api-serializer.js
@@ -265,7 +265,7 @@ function normalizeLinkage(linkage) {
   if(!linkage.type) { return linkage.id; }
   return {
     id: linkage.id,
-    type: Ember.String.camelize(linkage.type.singularize())
+    type: Ember.String.camelize(Ember.String.singularize(linkage.type))
   };
 }
 function getLinkageId(linkage) {


### PR DESCRIPTION
As mentioned [here](https://github.com/eneuhauser/ember-json-api/pull/2/files#r27578035), it's not safe to rely on String prototype extensions. This fixes that.

cc @iezer @kurko
