### PR TITLE
Disable Ember prototype extensions in tests

### DIFF
--- a/src/json-api-adapter.js
+++ b/src/json-api-adapter.js
@@ -1,3 +1,4 @@
+/* global Ember, DS */
 var get = Ember.get;
 
 /**
@@ -102,7 +103,9 @@ DS.JsonApiAdapter = DS.RESTAdapter.extend({
   findHasMany: function(store, snapshot, url, relationship) {
     var hasManyLoaded = snapshot.hasMany(relationship.key).filter(function(item) { return !item.record.get('currentState.isEmpty'); });
 
-    if(hasManyLoaded.get('length')) { return new Ember.RSVP.Promise(function (resolve, reject) { reject(); }); }
+    if(get(hasManyLoaded, 'length')) {
+      return new Ember.RSVP.Promise(function (resolve, reject) { reject(); });
+    }
 
     return this._super(store, snapshot, url, relationship);
   },

--- a/src/json-api-serializer.js
+++ b/src/json-api-serializer.js
@@ -1,3 +1,4 @@
+/* global Ember,DS */
 var get = Ember.get;
 var isNone = Ember.isNone;
 var HOST = /(^https?:\/\/.*?)(\/.*)/;
@@ -210,7 +211,7 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
     var belongsTo = record.belongsTo(attr);
     var type, key;
 
-    if (isNone(belongsTo)) return;
+    if (isNone(belongsTo)) { return; }
 
     type = this.keyForSnapshot(belongsTo);
     key = this.keyForRelationship(attr);
@@ -246,7 +247,7 @@ function belongsToLink(key, type, value) {
 }
 
 function hasManyLink(key, type, record, attr) {
-  var links = record.hasMany(attr).mapBy('id') || [];
+  var links = Ember.A(record.hasMany(attr)).mapBy('id') || [];
   var typeName = Ember.String.pluralize(type);
   var linkages = [];
   var index, total;
@@ -265,7 +266,7 @@ function normalizeLinkage(linkage) {
   if(!linkage.type) { return linkage.id; }
   return {
     id: linkage.id,
-    type: Ember.String.camelize(linkage.type.singularize())
+    type: Ember.String.camelize(Ember.String.singularize(linkage.type))
   };
 }
 function getLinkageId(linkage) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -7,6 +7,9 @@
   <script>
     window.TEST = true;
     window.ENV = {};
+    window.EmberENV = {
+      EXTEND_PROTOTYPES: false
+    };
   </script>
 </head>
 <body>


### PR DESCRIPTION
This turns off the usage of Ember prototype extensions in tests, and modifies the code in a couple places where it assumed prototype extensions would be there.
- Change `[].get('length')` into `get([], 'length')`
- Change `[].mapBy` to `Ember.A([]).mapBy`
