### PR TITLE
Handling top level links (e.g. pagination)

### DIFF
--- a/src/json-api-serializer.js
+++ b/src/json-api-serializer.js
@@ -58,8 +58,15 @@ DS.JsonApiSerializer = DS.RESTSerializer.extend({
       delete payload.meta;
     }
     if (payload.links) {
-      // FIXME Need to handle top level links, like pagination
-      //this.extractRelationships(payload.links, payload);
+      var type = data.length > 0 ? data[0].type : null;
+      if (type) {
+        type = Ember.String.camelize(Ember.String.singularize(type))
+        var metadata = {};
+        for (var link in payload.links) {
+          metadata[link] = payload.links[link];
+        }
+        get(this, 'store').setMetadataFor(type, metadata);
+      }
       delete payload.links;
     }
     if (payload[this.sideloadedRecordsKey]) {

--- a/tests/integration/specs/resource-collection-representations-test.js
+++ b/tests/integration/specs/resource-collection-representations-test.js
@@ -20,6 +20,20 @@ module('integration/specs/resource-collection-representations', {
       },
       empty_list: {
         data: []
+      },
+      paginated_posts_list: {
+        links: {
+          'last': '/api/posts?page[number]=1&page[size]=10'
+        },
+        data: [{
+          type: 'posts',
+          id: '1',
+          title: 'Rails is Omakase'
+        }, {
+          type: 'posts',
+          id: '2',
+          title: 'Ember.js Handlebars'
+        }]
       }
     };
 
@@ -58,6 +72,25 @@ asyncTest('GET empty /posts', function() {
 
   env.store.find('post').then(function(record) {
     equal(record.get('length'), 0, 'length is correct');
+    start();
+  });
+});
+
+asyncTest('GET paginated /posts', function() {
+  fakeServer.get('/posts', responses.paginated_posts_list);
+  env.store.find('post').then(function(record) {
+    var post1 = record.get("firstObject"),
+        post2 = record.get("lastObject");
+
+    equal(record.get('length'), 2, 'length is correct');
+
+    equal(post1.get('id'), '1', 'id is correct');
+    equal(post1.get('title'), 'Rails is Omakase', 'title is correct');
+
+    equal(post2.get('id'), '2', 'id is correct');
+    equal(post2.get('title'), 'Ember.js Handlebars', 'title is correct');
+
+    equal(env.store.metadataFor('post').last, responses.paginated_posts_list.links.last);
     start();
   });
 });


### PR DESCRIPTION
This is a naive implementation for handling top level links as model metadata. It could be improved by using a white list for allowed attributes.
